### PR TITLE
Fix log sort order and improve multi-container support

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -48,10 +48,10 @@ jobs:
         run: |
           # Run ruff check and capture output
           ruff check . --output-format=json > ruff-issues.json || true
-          
+
           # Run ruff format and capture changes, ensuring valid JSON output
           ruff format . --output-format=json > ruff-format.json || echo "[]" > ruff-format.json
-          
+
           # Create a comment with the issues if any
           if [ -s ruff-issues.json ] || [ -s ruff-format.json ]; then
             echo "RUFF_ISSUES=$(cat ruff-issues.json)" >> $GITHUB_ENV
@@ -66,11 +66,11 @@ jobs:
             // Debug output
             console.log('RUFF_ISSUES:', process.env.RUFF_ISSUES);
             console.log('RUFF_FORMAT:', process.env.RUFF_FORMAT);
-            
+
             // Parse with error handling
             let issues = [];
             let format = [];
-            
+
             try {
               if (process.env.RUFF_ISSUES) {
                 issues = JSON.parse(process.env.RUFF_ISSUES);
@@ -78,7 +78,7 @@ jobs:
             } catch (e) {
               console.error('Error parsing RUFF_ISSUES:', e);
             }
-            
+
             try {
               if (process.env.RUFF_FORMAT) {
                 format = JSON.parse(process.env.RUFF_FORMAT);
@@ -86,23 +86,23 @@ jobs:
             } catch (e) {
               console.error('Error parsing RUFF_FORMAT:', e);
             }
-            
+
             let message = '## Ruff Code Quality Issues\n\n';
-            
+
             if (issues.length > 0) {
               message += '### Linting Issues\n';
               issues.forEach(issue => {
                 message += `- ${issue.message} (${issue.filename}:${issue.line})\n`;
               });
             }
-            
+
             if (format.length > 0) {
               message += '\n### Formatting Issues\n';
               format.forEach(change => {
                 message += `- ${change.filename} needs formatting\n`;
               });
             }
-            
+
             // Only add fix commands if there are actual issues
             if (issues.length > 0 || format.length > 0) {
               message += '\n\nTo fix these issues, run:\n```bash\n';
@@ -114,7 +114,7 @@ jobs:
               }
               message += '```';
             }
-            
+
             // Only create comment if there are actual issues
             if (issues.length > 0 || format.length > 0) {
               github.rest.issues.createComment({
@@ -166,6 +166,27 @@ jobs:
         env:
           PYTHONPATH: .
           TEST_BASE_URL: "http://localhost:5001"
+
+      - name: Test previous logs functionality
+        run: |
+          # get the pod name
+          pod_name=$(kubectl get pods -n log-viewer-testing -l app=log-gen-deployment -o jsonpath='{.items[0].metadata.name}')
+          echo "Pod name: $pod_name"
+          # delete the pod
+          kubectl delete pod $pod_name -n log-viewer-testing
+          # wait for ready
+          kubectl wait -n log-viewer-testing --for=condition=ready pod --selector app.kubernetes.io/name=log-gen-deployment --timeout=120s
+
+          # get the logs from the api http://wsl:5001/api/archived_pods
+          logs=$(curl -s http://localhost:5001/api/archived_pods)
+          echo "Logs: $logs"
+          # check if the logs contain the string captured from pod_name
+          if echo "$logs" | grep -q "$pod_name"; then
+            echo "Logs contain the string captured from pod_name"
+          else
+            echo "Logs do not contain the string captured from pod_name, which was $pod_name"
+            exit 1
+          fi
 
       - name: Cleanup port forwarding
         if: always()

--- a/charts/kube-web-log-viewer/src/log_archiver.py
+++ b/charts/kube-web-log-viewer/src/log_archiver.py
@@ -195,6 +195,7 @@ def watch_pods_and_archive(namespace, v1, log_dir, logger):
             logger.error(f"Error in pod watcher: {e}")
             time.sleep(60)  # Wait before retrying
 
+
 def purge_previous_pod_logs(log_dir, logger):
     """
     Deletes only the previous pod log files in the specified directory.

--- a/charts/kube-web-log-viewer/src/main.py
+++ b/charts/kube-web-log-viewer/src/main.py
@@ -455,10 +455,9 @@ def get_archived_pods():
                     # Remove .log extension to get pod/container name
                     pod_container = filename[:-4]
                     # Exclude current pod and any currently running pods
-                    if (KUBE_POD_NAME not in pod_container and 
-                        pod_container not in running_pod_containers):
+                    if KUBE_POD_NAME not in pod_container and pod_container not in running_pod_containers:
                         archived_pod_names.append(pod_container)
-            
+
             app.logger.info(f"Found {len(archived_pod_names)} previous (non-running) pod/container logs in {LOG_DIR}.")
         except OSError as e:
             app.logger.error(f"Error listing previous pod logs directory {LOG_DIR}: {e}")
@@ -637,11 +636,13 @@ def get_purge_capability():
     """
     global RETAIN_ALL_POD_LOGS, ALLOW_PREVIOUS_LOG_PURGE
 
-    return jsonify({
-        "purge_allowed": RETAIN_ALL_POD_LOGS and ALLOW_PREVIOUS_LOG_PURGE,
-        "logs_enabled": RETAIN_ALL_POD_LOGS,
-        "purge_enabled": ALLOW_PREVIOUS_LOG_PURGE
-    })
+    return jsonify(
+        {
+            "purge_allowed": RETAIN_ALL_POD_LOGS and ALLOW_PREVIOUS_LOG_PURGE,
+            "logs_enabled": RETAIN_ALL_POD_LOGS,
+            "purge_enabled": ALLOW_PREVIOUS_LOG_PURGE,
+        }
+    )
 
 
 @app.route("/api/purgePreviousLogs", methods=["POST"])

--- a/charts/kube-web-log-viewer/templates/NOTES.txt
+++ b/charts/kube-web-log-viewer/templates/NOTES.txt
@@ -1,15 +1,11 @@
+{{ .Chart.Version }} installed
 1. Get the application URL by running these commands:
-{{- if contains "ClusterIP" .Values.service.type }}
-  export SERVICE_NAME=$(kubectl get svc --namespace {{ .Release.Namespace }} -l "{{ include "kube-web-log-viewer.selectorLabels" . }}" -o jsonpath="{.items[0].metadata.name}")
-  export SERVICE_PORT=$(kubectl get svc --namespace {{ .Release.Namespace }} $SERVICE_NAME -o jsonpath="{.spec.ports[0].port}")
-  echo "Visit http://127.0.0.1:{{ .Values.service.port }} to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $SERVICE_NAME {{ .Values.service.port }}:$SERVICE_PORT
-{{- end }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "kube-web-log-viewer.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
 
 2. Configuration:
-   - Log archival: {{ if .Values.previousPodLogs.enabled }}ENABLED{{ else }}DISABLED{{ end }}
+   - Previous pod log retention: {{ if .Values.previousPodLogs.enabled }}ENABLED{{ else }}DISABLED{{ end }}
    {{- if .Values.previousPodLogs.enabled }}
-   - Log retention: {{ .Values.previousPodLogs.retentionMinutes }} minutes ({{ div .Values.previousPodLogs.retentionMinutes 1440 }} days)
+   - Log retention time: {{ .Values.previousPodLogs.retentionMinutes }} minutes ({{ div .Values.previousPodLogs.retentionMinutes 1440 }} days)
    - Purge capability: {{ if .Values.previousPodLogs.allowPurge }}ENABLED{{ else }}DISABLED{{ end }}
    {{- end }}
    - API authentication: {{ if and .Values.auth.apiKey (ne .Values.auth.apiKey "no-key") }}ENABLED{{ else }}DISABLED{{ end }}
@@ -24,8 +20,3 @@
    {{- else }}
    - Using emptyDir (logs will be lost on pod restart)
    {{- end }}
-
-4. Troubleshooting:
-   - Check pod status: kubectl get pods -n {{ .Release.Namespace }} -l "{{ include "kube-web-log-viewer.selectorLabels" . }}"
-   - View logs: kubectl logs -n {{ .Release.Namespace }} -l "{{ include "kube-web-log-viewer.selectorLabels" . }}"
-   - Check readiness: kubectl get pods -n {{ .Release.Namespace }} -l "{{ include "kube-web-log-viewer.selectorLabels" . }}" -o wide

--- a/charts/kube-web-log-viewer/values.yaml
+++ b/charts/kube-web-log-viewer/values.yaml
@@ -30,7 +30,7 @@ replicaCount: 1
 
 image:
   repository: python
-  tag: "3.13-slim"
+  tag: 3.13-slim
   pullPolicy: IfNotPresent
 
 # Ingress configuration

--- a/src/index.html
+++ b/src/index.html
@@ -503,7 +503,7 @@
 
                 const params = new URLSearchParams({
                     pod_name: actualPodName,
-                    sort_order: isArchivedLog ? (sortOrder.value === 'asc' ? 'desc' : 'asc') : sortOrder.value,
+                    sort_order: sortOrder.value,
                     tail_lines: numLines.value,
                     search_string: searchBox.value.trim(),
                 });

--- a/src/log_archiver.py
+++ b/src/log_archiver.py
@@ -231,34 +231,56 @@ def purge_previous_pod_logs(log_dir, logger):
     deleted_count = 0
     error_count = 0
 
-    # Get list of current pods
+    # Get list of current pod/container combinations
     try:
         v1 = client.CoreV1Api()
         namespace = os.environ.get("K8S_NAMESPACE", "default")
         pod_list = v1.list_namespaced_pod(namespace=namespace)
-        current_pods = {pod.metadata.name for pod in pod_list.items}
+        current_pod_containers = set()
+
+        for pod in pod_list.items:
+            pod_name = pod.metadata.name
+            containers = [container.name for container in pod.spec.containers]
+            init_containers = [container.name for container in (pod.spec.init_containers or [])]
+
+            # Add init containers with "init-" prefix
+            for init_container in init_containers:
+                current_pod_containers.add(f"{pod_name}/init-{init_container}")
+
+            # Add regular containers
+            if len(containers) == 1 and not init_containers:
+                current_pod_containers.add(pod_name)
+            else:
+                # For pods with multiple containers or any init containers, add each container as pod/container
+                for container in containers:
+                    current_pod_containers.add(f"{pod_name}/{container}")
+
     except Exception as e:
         logger.error(f"Error getting current pod list: {e}")
         return 0, 1
 
-    for filename in os.listdir(log_dir):
-        if filename.endswith(".log"):  # Process only .log files
-            file_path = os.path.join(log_dir, filename)
-            try:
-                # Extract pod name from filename (remove .log extension and container name if present)
-                pod_name = filename.split("/")[0] if "/" in filename else filename[:-4]
+    # Use os.walk to search subdirectories since multi-container pods create subdirectories
+    for root, dirs, files in os.walk(log_dir):
+        for filename in files:
+            if filename.endswith(".log"):  # Process only .log files
+                file_path = os.path.join(root, filename)
+                try:
+                    # Get relative path from log_dir to construct pod/container name
+                    relative_path = os.path.relpath(file_path, log_dir)
+                    # Remove .log extension to get pod/container name
+                    pod_container = relative_path[:-4]
 
-                # Only delete if this pod is not in the current pod list
-                if pod_name not in current_pods:
-                    os.remove(file_path)
-                    logger.info(f"Purged previous pod log file: {file_path}")
-                    deleted_count += 1
-            except OSError as e:
-                logger.error(f"Error purging file {file_path}: {e}")
-                error_count += 1
-            except Exception as e:
-                logger.error(f"Unexpected error processing file {file_path}: {e}")
-                error_count += 1
+                    # Only delete if this pod/container is not in the current pod list
+                    if pod_container not in current_pod_containers:
+                        os.remove(file_path)
+                        logger.info(f"Purged previous pod log file: {file_path}")
+                        deleted_count += 1
+                except OSError as e:
+                    logger.error(f"Error purging file {file_path}: {e}")
+                    error_count += 1
+                except Exception as e:
+                    logger.error(f"Unexpected error processing file {file_path}: {e}")
+                    error_count += 1
 
     logger.info(f"Previous pod logs purge finished. Deleted: {deleted_count}, Errors: {error_count}")
     return deleted_count, error_count

--- a/src/log_archiver.py
+++ b/src/log_archiver.py
@@ -195,6 +195,7 @@ def watch_pods_and_archive(namespace, v1, log_dir, logger):
             logger.error(f"Error in pod watcher: {e}")
             time.sleep(60)  # Wait before retrying
 
+
 def purge_previous_pod_logs(log_dir, logger):
     """
     Deletes only the previous pod log files in the specified directory.

--- a/src/main.py
+++ b/src/main.py
@@ -455,10 +455,9 @@ def get_archived_pods():
                     # Remove .log extension to get pod/container name
                     pod_container = filename[:-4]
                     # Exclude current pod and any currently running pods
-                    if (KUBE_POD_NAME not in pod_container and 
-                        pod_container not in running_pod_containers):
+                    if KUBE_POD_NAME not in pod_container and pod_container not in running_pod_containers:
                         archived_pod_names.append(pod_container)
-            
+
             app.logger.info(f"Found {len(archived_pod_names)} previous (non-running) pod/container logs in {LOG_DIR}.")
         except OSError as e:
             app.logger.error(f"Error listing previous pod logs directory {LOG_DIR}: {e}")
@@ -637,11 +636,13 @@ def get_purge_capability():
     """
     global RETAIN_ALL_POD_LOGS, ALLOW_PREVIOUS_LOG_PURGE
 
-    return jsonify({
-        "purge_allowed": RETAIN_ALL_POD_LOGS and ALLOW_PREVIOUS_LOG_PURGE,
-        "logs_enabled": RETAIN_ALL_POD_LOGS,
-        "purge_enabled": ALLOW_PREVIOUS_LOG_PURGE
-    })
+    return jsonify(
+        {
+            "purge_allowed": RETAIN_ALL_POD_LOGS and ALLOW_PREVIOUS_LOG_PURGE,
+            "logs_enabled": RETAIN_ALL_POD_LOGS,
+            "purge_enabled": ALLOW_PREVIOUS_LOG_PURGE,
+        }
+    )
 
 
 @app.route("/api/purgePreviousLogs", methods=["POST"])

--- a/src/main.py
+++ b/src/main.py
@@ -605,11 +605,17 @@ def get_archived_logs():
 
         app.logger.info(f"{len(processed_logs)} lines after search filter for archived pod/container '{pod_name}'.")
 
-        if sort_order == "desc":  # Newest first
-            processed_logs.reverse()
+        # Sort by timestamp
+        processed_logs.sort(
+            key=lambda x: x.get("timestamp") or "0000-00-00T00:00:00Z",
+            reverse=(sort_order == "desc"),
+        )
 
         if tail_lines is not None and tail_lines > 0:
-            processed_logs = processed_logs[:tail_lines]
+            if sort_order == "desc":
+                processed_logs = processed_logs[:tail_lines]
+            else:
+                processed_logs = processed_logs[-tail_lines:]
 
         return jsonify({"logs": processed_logs})
 

--- a/src/main.py
+++ b/src/main.py
@@ -493,11 +493,11 @@ def get_archived_pods():
                     pod_name = pod.metadata.name
                     containers = [container.name for container in pod.spec.containers]
                     init_containers = [container.name for container in (pod.spec.init_containers or [])]
-                    
+
                     # Add init containers with "init-" prefix
                     for init_container in init_containers:
                         running_pod_containers.add(f"{pod_name}/init-{init_container}")
-                    
+
                     # Add regular containers
                     if len(containers) == 1 and not init_containers:
                         running_pod_containers.add(pod_name)

--- a/tests/log-gen-deployment.yaml
+++ b/tests/log-gen-deployment.yaml
@@ -7,7 +7,7 @@ data:
     import time
     import sys
 
-    log_levels = ['info', 'inf', 'wrn', 'warn', 'err', 'error', 'panic']
+    log_levels = sorted(['alert', 'crit', 'debug', 'dbg', 'emerg', 'error', 'fatal', 'inf', 'info', 'notice', 'panic', 'trace', 'warn', 'warning', 'wrn'])
     index = 0
 
     while True:
@@ -33,6 +33,10 @@ spec:
       labels:
         app: log-gen
     spec:
+      initContainers:
+      - name: init-container
+        image: python:3.13-slim
+        command: ["python", "-c", "print('[INFO] Hello from init container!', flush=True)"]
       containers:
       - name: log-gen
         image: python:3.13-slim

--- a/tests/log-gen-deployment.yaml
+++ b/tests/log-gen-deployment.yaml
@@ -33,6 +33,7 @@ spec:
       labels:
         app: log-gen
     spec:
+      terminationGracePeriodSeconds: 1
       initContainers:
       - name: init-container
         image: python:3.13-slim

--- a/tests/test_app_playwright.py
+++ b/tests/test_app_playwright.py
@@ -199,3 +199,161 @@ def test_log_viewer_e2e(page: Page):
         page.screenshot(path=screenshot_path)
         print(f"Test failed: {e}")
         pytest.fail(f"Test failed due to: {e}")
+
+
+def test_sort_order_functionality(page: Page):
+    """
+    Test sort order functionality for live pods, archived pods, and all pods view.
+    1. Tests newest first and oldest first for live pods
+    2. Tests newest first and oldest first for archived pods (if available)
+    3. Tests newest first and oldest first for all pods view
+    """
+    try:
+        # Navigate to the app
+        page.goto(APP_BASE_URL, timeout=NAV_TIMEOUT)
+        page.wait_for_load_state("networkidle", timeout=NAV_TIMEOUT)
+
+        # Wait for namespace to be displayed
+        namespace_display = page.locator("#namespaceValue")
+        expect(namespace_display).not_to_have_text("Loading...", timeout=NAV_TIMEOUT)
+        expect(namespace_display).not_to_have_text("Error loading", timeout=ACTION_TIMEOUT)
+
+        pod_selector = page.locator("#podSelector")
+        sort_order_selector = page.locator("#sortOrder")
+        log_output = page.locator("#logOutput")
+        loading_indicator = page.locator("#loadingIndicator")
+
+        # Wait for pod selector to be populated
+        expect(pod_selector).to_be_visible(timeout=NAV_TIMEOUT)
+        expect(pod_selector.locator("optgroup[label='Live Pods'] option")).to_have_count(1, timeout=NAV_TIMEOUT)
+
+        # Find the log-gen pod
+        log_gen_pod_option_locator = pod_selector.locator(f"option[value^='{LOG_GEN_POD_NAME_PREFIX}']")
+        if not log_gen_pod_option_locator.count():
+            log_gen_pod_option_locator = pod_selector.locator(f"optgroup > option[value^='{LOG_GEN_POD_NAME_PREFIX}']")
+
+        expect(log_gen_pod_option_locator).not_to_have_count(0, timeout=NAV_TIMEOUT)
+        log_gen_pod_value = log_gen_pod_option_locator.first.get_attribute("value")
+        if log_gen_pod_value is None:
+            raise ValueError("log_gen_pod_option does not have a value attribute")
+
+        # Helper function to get timestamps from log entries
+        def get_log_timestamps():
+            page.wait_for_function(
+                """
+                () => {
+                    const content = document.querySelector('#logOutput').textContent;
+                    return content && content.trim().length > 0 && 
+                           !content.includes('No logs to display') && 
+                           !content.includes('Error loading logs');
+                }
+                """,
+                timeout=LOG_LOAD_TIMEOUT,
+            )
+
+            # Get all log lines with timestamps
+            log_lines = log_output.locator("div.log-line")
+            timestamps = []
+            for i in range(min(log_lines.count(), 5)):  # Check first 5 lines
+                line = log_lines.nth(i)
+                timestamp_span = line.locator("span.timestamp")
+                if timestamp_span.count() > 0:
+                    timestamp_text = timestamp_span.text_content()
+                    if timestamp_text:
+                        timestamps.append(timestamp_text.strip())
+            return timestamps
+
+        # Test 1: Live pod with newest first (default)
+        print("Testing live pod with newest first...")
+        pod_selector.select_option(log_gen_pod_value)
+        expect(loading_indicator).to_be_hidden(timeout=LOG_LOAD_TIMEOUT)
+
+        sort_order_selector.select_option("desc")  # Newest first
+        expect(loading_indicator).to_be_hidden(timeout=LOG_LOAD_TIMEOUT)
+
+        newest_first_timestamps = get_log_timestamps()
+        print(f"Newest first timestamps: {newest_first_timestamps[:3]}")
+
+        # Test 2: Live pod with oldest first
+        print("Testing live pod with oldest first...")
+        sort_order_selector.select_option("asc")  # Oldest first
+        expect(loading_indicator).to_be_hidden(timeout=LOG_LOAD_TIMEOUT)
+
+        oldest_first_timestamps = get_log_timestamps()
+        print(f"Oldest first timestamps: {oldest_first_timestamps[:3]}")
+
+        # Verify that the order is different (unless there's only one log entry)
+        if len(newest_first_timestamps) > 1 and len(oldest_first_timestamps) > 1:
+            assert newest_first_timestamps != oldest_first_timestamps, "Sort order should change timestamps order"
+            # First timestamp in newest-first should be newer than first in oldest-first
+            assert (
+                newest_first_timestamps[0] >= oldest_first_timestamps[0]
+            ), "Newest first should show newer logs at top"
+
+        # Test 3: Check if archived pods are available
+        archived_pod_options = pod_selector.locator("optgroup[label='Archived Pods'] option")
+        archived_pod_count = archived_pod_options.count()
+
+        if archived_pod_count > 0:
+            print(f"Testing archived pods (found {archived_pod_count})...")
+
+            # Select first archived pod
+            archived_pod_value = archived_pod_options.first.get_attribute("value")
+            pod_selector.select_option(archived_pod_value)
+            expect(loading_indicator).to_be_hidden(timeout=LOG_LOAD_TIMEOUT)
+
+            # Test newest first for archived pod
+            sort_order_selector.select_option("desc")
+            expect(loading_indicator).to_be_hidden(timeout=LOG_LOAD_TIMEOUT)
+
+            archived_newest_first = get_log_timestamps()
+            print(f"Archived newest first: {archived_newest_first[:3]}")
+
+            # Test oldest first for archived pod
+            sort_order_selector.select_option("asc")
+            expect(loading_indicator).to_be_hidden(timeout=LOG_LOAD_TIMEOUT)
+
+            archived_oldest_first = get_log_timestamps()
+            print(f"Archived oldest first: {archived_oldest_first[:3]}")
+
+            # Verify order is different for archived logs too
+            if len(archived_newest_first) > 1 and len(archived_oldest_first) > 1:
+                assert archived_newest_first != archived_oldest_first, "Archived logs sort order should change"
+        else:
+            print("No archived pods found, skipping archived pod sort tests")
+
+        # Test 4: All pods view
+        print("Testing all pods view...")
+        pod_selector.select_option("all")
+        expect(loading_indicator).to_be_hidden(timeout=LOG_LOAD_TIMEOUT)
+
+        # Test newest first for all pods
+        sort_order_selector.select_option("desc")
+        expect(loading_indicator).to_be_hidden(timeout=LOG_LOAD_TIMEOUT)
+
+        all_pods_newest_first = get_log_timestamps()
+        print(f"All pods newest first: {all_pods_newest_first[:3]}")
+
+        # Test oldest first for all pods
+        sort_order_selector.select_option("asc")
+        expect(loading_indicator).to_be_hidden(timeout=LOG_LOAD_TIMEOUT)
+
+        all_pods_oldest_first = get_log_timestamps()
+        print(f"All pods oldest first: {all_pods_oldest_first[:3]}")
+
+        # Verify order is different for all pods view
+        if len(all_pods_newest_first) > 1 and len(all_pods_oldest_first) > 1:
+            assert all_pods_newest_first != all_pods_oldest_first, "All pods sort order should change"
+
+        print("Sort order functionality test completed successfully.")
+
+    except Exception as e:
+        # Capture a screenshot on failure
+        screenshot_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "test-results",
+            "test-failure-sort-screenshot.png",
+        )
+        page.screenshot(path=screenshot_path)
+        print(f"Sort order test failed: {e}")
+        pytest.fail(f"Sort order test failed due to: {e}")


### PR DESCRIPTION
## Summary
• Fix reversed sort order for archived pod logs
• Remove frontend sort order workaround for archived logs  
• Improve multi-container pod support in log archival and purging
• Add comprehensive end-to-end tests for sort functionality across all pod viewing modes

## Test plan
- [x] Backend sort order fix: Replace simple reverse() with timestamp-based sorting
- [x] Frontend fix: Remove sort order reversal logic for archived logs  
- [x] Multi-container improvements: Better handling of init containers and subdirectories
- [x] Comprehensive tests: Test newest/oldest first for live pods, archived pods, and all pods view
- [x] Code quality: All tests pass, linting clean

🤖 Generated with [Claude Code](https://claude.ai/code)